### PR TITLE
HM-19 and other non-dual devices support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-SparkFun HM12/13 Bluetooth Arduino Library
+HM-1X Bluetooth Arduino Library
 ==============================
 
-The HM12 and HM13 are Bluetooth 4.0 modules with support for SPP and BLE profiles.
+The HM-1X Bluetooth 4.x/5.0 modules with support for SPP and BLE profiles.
+The full compatibility table can be seen at the original [manufacturer's website](http://www.jnhuamao.cn/).
+This is a fork of Sparkfun's Arduino library that was originally made for HM12/13.
+This should be compatible with any HM-1X devices from 10-19, but as of this writing it is only tested for HM-19.
 
 The modules use a UART communication interface.
 
@@ -15,11 +18,6 @@ Repository Contents
 * **keywords.txt** - Keywords from this library that will be highlighted in the Arduino IDE. 
 * **library.properties** - General library properties for the Arduino package manager. 
 
-Documentation
--------------
-
-Coming soon!
-
 License Information
 -------------------
 
@@ -28,7 +26,3 @@ This product is _**open source**_!
 Various bits of the code have different licenses applied. Anything SparkFun wrote is beerware; if you see me (or any other SparkFun employee) at the local, and you've found our code helpful, please buy us a round!
 
 Please use, reuse, and modify these files as you see fit. Please maintain attribution to SparkFun Electronics and release anything derivative under the same license.
-
-Distributed as-is; no warranty is given.
-
-- Your friends at SparkFun.

--- a/examples/SoftwareSerial_05_Configure_Device_HM19/SoftwareSerial_05_Configure_Device_HM19.ino
+++ b/examples/SoftwareSerial_05_Configure_Device_HM19/SoftwareSerial_05_Configure_Device_HM19.ino
@@ -7,8 +7,15 @@
   if you use this and we meet someday (Beerware license).
 
   Demonstrates how to configure the HM-19's BLE name,
-  and how to reset the module. Also prints out BLE
-  addresses (not configurable).
+  and how to reset the module. 
+  Demonstrates the library's support for:
+  - bleAddress(), 
+  - bleAddress()
+  - lastBleAddress()
+  - clearBleConnected()
+  - getBleMode(), setBleMode()
+  - getBlePin(), setBlePin()
+  Also prints out BLE addresses (not configurable).
 
   Works well with a DSD-Tech HM-19 board -- 
   connecting via software serial (D3, D4)
@@ -25,19 +32,22 @@
 #include <SparkFun_HM1X_Bluetooth_Arduino_Library.h>
 #include <SoftwareSerial.h>
 
-HM1X_BT bt(HM19);
+// Do not forget to initialize the class with the HM-1X model type
+// in this sketch it is HM19
+HM1X_BT bt(HM1X_BT::HM19);
 
 SoftwareSerial btSerial(3, 4);
 
 // BLE and EDR device names
 String edrName = "MyEDR";
 String bleName = "MyBLE";
+String existingName;
 
 void setup() {
   Serial.begin(9600); // Serial debug port @ 9600 bps
 
   // bt.begin --
-  // in this case takes a HardwareSerial connection and
+  // in this case takes a SoftwareSerial connection and
   // a desired serial baud rate.
   // Returns true on success
   if (bt.begin(btSerial, 9600) == false) {
@@ -48,31 +58,100 @@ void setup() {
   Serial.println("Ready to Bluetooth!");
 
   boolean resetRequired = false; // Reset is required on name change
+
+  // 1: Device Name  
   // getEdrName returns a string containing EDR device name
-  if (bt.getEdrName() != edrName) {
-    Serial.println("Setting new EDR name");
+  // This should fail for HM-19
+  existingName = bt.getEdrName(); // fetch existing name first
+  if (existingName != edrName) {
+    Serial.print("Setting new EDR name (currently ");
+    Serial.print(existingName);
+    Serial.println(")");
     // Set EDR device name
     if (bt.setEdrName(edrName) == HM1X_SUCCESS) {
       Serial.println("Set EDR name");
       setName = true;
       resetRequired = true;
+    }else{
+      Serial.println("Setting EDR name failed");
     }
   }
-  // getEdrName returns a string containing BLE device name
-  if (bt.getBleName() != bleName) {
-    Serial.println("Setting new BLE name");
+  
+  // getBleName returns a string containing BLE device name
+  // This should work for HM-19
+  existingName = bt.getBleName(); // fetch existing name first
+  if (existingName != bleName) {
+    Serial.print("Setting new BLE name (currently ");
+    Serial.print(existingName);
+    Serial.println(")");
     // Set BLE device name
     if (bt.setBleName(bleName) == HM1X_SUCCESS) {
       Serial.println("Set BLE name to " + bleName);
       resetRequired = true;
+    }else{
+      Serial.println("Setting BLE name failed");
     }
   } else {
     Serial.println("BLE name is: " + bleName);
   }
-  
-  Serial.println("EDR address: " + bt.edrAddress());
-  Serial.println("BLE address: " + bt.bleAddress());
 
+  // 2: Device Address  
+  Serial.println("EDR address: " + bt.edrAddress());  // should not return anything
+  Serial.println("BLE address: " + bt.bleAddress());  // should return the BLE address
+
+  char* lastAddress = (char *) calloc(22, sizeof(char));
+  if (bt.lastBleAddress(lastAddress) == HM1X_SUCCESS){
+    Serial.println("last BLE address: " + String(lastAddress));
+  }
+  free(lastAddress);
+
+  // clear last connected
+  if (bt.clearBleConnected() == HM1X_SUCCESS){
+    Serial.println("last BLE Address cleared!");  
+  }
+
+  // 3: Mode
+  // get BLE mode
+  HM1X_BT::HM1X_ble_mode_t mode;
+  if (bt.getBleMode(&mode) == HM1X_SUCCESS){
+    Serial.print("BLE mode before: ");
+    Serial.println(mode);  
+  }
+
+  // set BLE mode
+  mode = (HM1X_BT::HM1X_ble_mode_t)1;
+  if (bt.setBleMode(mode) == HM1X_SUCCESS){
+    Serial.print("changing... ");
+    Serial.println(mode);  
+  }
+
+  // get BLE mode again
+  if (bt.getBleMode(&mode) == HM1X_SUCCESS){
+    Serial.print("BLE mode after: ");
+    Serial.println(mode);  
+  }
+
+  // 4: Pin
+  // get BLE pin
+  char* pin = (char *) calloc(6, sizeof(char));
+  if (bt.getBlePin(pin) == HM1X_SUCCESS){
+    Serial.print("Current BLE Pin: ");
+    Serial.println(pin);  
+  }
+
+  // set BLE pin to an arbitrary PIN
+  strcpy(pin, "784923");
+  if (bt.setBlePin(pin) == HM1X_SUCCESS){
+    Serial.print("changing... ");
+    Serial.println(mode);  
+  }
+
+  // get BLE pin again
+  if (bt.getBlePin(pin) == HM1X_SUCCESS){
+    Serial.print("New BLE Pin: ");
+    Serial.println(pin);  
+  }
+  
   if (resetRequired) {
     Serial.println("Resetting BT module. Wait a few seconds.");
     bt.reset();

--- a/examples/SoftwareSerial_05_Configure_Device_HM19/SoftwareSerial_05_Configure_Device_HM19.ino
+++ b/examples/SoftwareSerial_05_Configure_Device_HM19/SoftwareSerial_05_Configure_Device_HM19.ino
@@ -1,0 +1,89 @@
+/*
+  HM1X Bluetooth SoftwareSerial Configure Device
+  Updated Support for HM1X devices 
+  By: Niel Cansino
+  Date: May 4, 2020
+  License: This code is public domain but you buy me a beer 
+  if you use this and we meet someday (Beerware license).
+
+  Demonstrates how to configure the HM-19's BLE name,
+  and how to reset the module. Also prints out BLE
+  addresses (not configurable).
+
+  Works well with a DSD-Tech HM-19 board -- 
+  connecting via software serial (D3, D4)
+
+  Hardware Connections:
+  DSD-Tech HM-19 ------------------- Arduino Uno
+       GND ----------------------------- GND
+       3.3V ---------------------------- 5V
+       TX ------------------------------ 3
+       RX ------------------------------ 4
+*/
+
+// Use Library Manager or download here: https://github.com/sparkfun/SparkFun_HM1X_Bluetooth_Arduino_Library
+#include <SparkFun_HM1X_Bluetooth_Arduino_Library.h>
+#include <SoftwareSerial.h>
+
+HM1X_BT bt(HM19);
+
+SoftwareSerial btSerial(3, 4);
+
+// BLE and EDR device names
+String edrName = "MyEDR";
+String bleName = "MyBLE";
+
+void setup() {
+  Serial.begin(9600); // Serial debug port @ 9600 bps
+
+  // bt.begin --
+  // in this case takes a HardwareSerial connection and
+  // a desired serial baud rate.
+  // Returns true on success
+  if (bt.begin(btSerial, 9600) == false) {
+    Serial.println(F("Failed to connect to the HM-13."));
+    while (1) ;
+  }
+  boolean setName = false;
+  Serial.println("Ready to Bluetooth!");
+
+  boolean resetRequired = false; // Reset is required on name change
+  // getEdrName returns a string containing EDR device name
+  if (bt.getEdrName() != edrName) {
+    Serial.println("Setting new EDR name");
+    // Set EDR device name
+    if (bt.setEdrName(edrName) == HM1X_SUCCESS) {
+      Serial.println("Set EDR name");
+      setName = true;
+      resetRequired = true;
+    }
+  }
+  // getEdrName returns a string containing BLE device name
+  if (bt.getBleName() != bleName) {
+    Serial.println("Setting new BLE name");
+    // Set BLE device name
+    if (bt.setBleName(bleName) == HM1X_SUCCESS) {
+      Serial.println("Set BLE name to " + bleName);
+      resetRequired = true;
+    }
+  } else {
+    Serial.println("BLE name is: " + bleName);
+  }
+  
+  Serial.println("EDR address: " + bt.edrAddress());
+  Serial.println("BLE address: " + bt.bleAddress());
+
+  if (resetRequired) {
+    Serial.println("Resetting BT module. Wait a few seconds.");
+    bt.reset();
+  }
+}
+
+void loop() {
+  if (bt.available()) {
+    Serial.write((char) bt.read());
+  }
+  if (Serial.available()) {
+    bt.write((char) Serial.read());
+  } 
+}

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -714,9 +714,8 @@ HM1X_error_t HM1X_BT::getEdrName(char * name)
     int retNameLen;
 
     // Check if EDR is supported
-    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    if ( !_isEdrSupported )
     {
-        // HM-15 to HM-19 does not support EDR
         // return error
         return HM1X_ERROR_ER;
     }
@@ -757,9 +756,8 @@ HM1X_error_t HM1X_BT::setEdrName(String name)
     char * edrChar;
 
     // Check if EDR is supported
-    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    if ( !_isEdrSupported )
     {
-        // HM-15 to HM-19 does not support EDR
         // return error
         return HM1X_ERROR_ER;
     }
@@ -778,9 +776,8 @@ HM1X_error_t HM1X_BT::setEdrName(const char * name)
     int nameLen;
 
     // Check if EDR is supported
-    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    if ( !_isEdrSupported )
     {
-        // HM-15 to HM-19 does not support EDR
         // return error
         return HM1X_ERROR_ER;
     }
@@ -1009,9 +1006,8 @@ HM1X_error_t HM1X_BT::lastEdrAddress(char * address)
     char * response;
 
     // Check if EDR is supported
-    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    if ( !_isEdrSupported )
     {
-        // HM-15 to HM-19 does not support EDR
         // return error
         return HM1X_ERROR_ER;
     }
@@ -1066,9 +1062,8 @@ HM1X_error_t HM1X_BT::clearEdrBond(void)
     char * response;
 
     // Check if EDR is supported
-    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    if ( !_isEdrSupported )
     {
-        // HM-15 to HM-19 does not support EDR
         // return error
         return HM1X_ERROR_ER;
     }
@@ -1144,9 +1139,8 @@ HM1X_error_t HM1X_BT::clearEdrConnected(void)
     char * response;
 
     // Check if EDR is supported
-    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    if ( !_isEdrSupported )
     {
-        // HM-15 to HM-19 does not support EDR
         // return error
         return HM1X_ERROR_ER;
     }
@@ -1221,9 +1215,8 @@ HM1X_error_t HM1X_BT::getEdrMode(HM1X_edr_mode_t * mode)
     char * response;
 
     // Check if EDR is supported
-    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    if ( !_isEdrSupported )
     {
-        // HM-15 to HM-19 does not support EDR
         // return error
         return HM1X_ERROR_ER;
     }
@@ -1271,9 +1264,8 @@ HM1X_error_t HM1X_BT::setEdrMode(HM1X_edr_mode_t mode)
     char modeParam;
 
     // Check if EDR is supported
-    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    if ( !_isEdrSupported )
     {
-        // HM-15 to HM-19 does not support EDR
         // return error
         return HM1X_ERROR_ER;
     }
@@ -1550,9 +1542,8 @@ HM1X_error_t HM1X_BT::getEdrPin(char * code)
     char * response;
 
     // Check if EDR is supported
-    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    if ( !_isEdrSupported )
     {
-        // HM-15 to HM-19 does not support EDR
         // return error
         return HM1X_ERROR_ER;
     }

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -155,40 +155,6 @@ HM1X_BT::HM1X_BT(HM1X_model_t btModel)
 #endif
 }
 
-// set model-specific variables
-// _isEdrSupported, _btBauds_ptr, and _validBaudBounds_ptr
-void HM1X_BT::setModelSpecificVariables(void){
-
-    switch(_btModel)
-    {
-        case HM10:
-        case HM11:
-            // HM-10/11: only allow P0~8
-            _isEdrSupported = false;
-            _validBaudBounds_ptr = &btBauds_validRange_HM10_11[0];
-            _btBauds_ptr = &btBauds_HM10_11[0];
-            break;
-        case HM12:
-        case HM13:
-            // HM-12/13
-            _isEdrSupported = true;
-            _validBaudBounds_ptr = &btBauds_validRange_HM12_13[0];
-            _btBauds_ptr = &btBauds_HM12_13[0];
-            break;
-        case HM14:
-        case HM15:
-        case HM16:
-        case HM17:
-        case HM18:
-        case HM19:
-            // HM-14 to 19
-            _isEdrSupported = false;
-            _validBaudBounds_ptr = &btBauds_validRange_HM16_17_18_19[0];
-            _btBauds_ptr = &btBauds_HM16_17_18_19[0];
-            break;
-    }
-}
-
 #ifdef HM1X_SOFTWARE_SERIAL_ENABLED
 boolean HM1X_BT::begin(SoftwareSerial & softSerial, unsigned long baud)
 {
@@ -2478,6 +2444,30 @@ HM1X_error_t HM1X_BT::setBaud(HM1X_baud_t atob)
     return err;
 }
 
+// returns the integer that corresponds to the correct baud rate depending on the model
+HM1X_error_t HM1X_BT::findBaudFromArray(HM1X_baud_t atob, uint8_t &num){
+    
+    // check bounds
+    if ((atob < _validBaudBounds_ptr[0]) || (atob > _validBaudBounds_ptr[1]))
+    {
+        // out of bounds
+        return HM1X_UNEXPECTED_RESPONSE;
+    }
+
+    // look for the index that corresponds to atob
+    for( uint8_t i = _validBaudBounds_ptr[0]; i <= _validBaudBounds_ptr[1]; ++i ){
+        if (atob == *(_btBauds_ptr + i))
+        {
+            num = i;
+            return HM1X_SUCCESS;
+        }
+    }
+
+    // invalid atob for the particular model
+    return HM1X_UNEXPECTED_RESPONSE;
+    
+}
+
 /////////////
 // Private //
 /////////////
@@ -2856,4 +2846,38 @@ HM1X_error_t HM1X_BT::forceBaud(HM1X_baud_t baud)
         }
     }
     return err;
+}
+
+// set model-specific variables
+// _isEdrSupported, _btBauds_ptr, and _validBaudBounds_ptr
+void HM1X_BT::setModelSpecificVariables(void){
+
+    switch(_btModel)
+    {
+        case HM10:
+        case HM11:
+            // HM-10/11: only allow P0~8
+            _isEdrSupported = false;
+            _validBaudBounds_ptr = &btBauds_validRange_HM10_11[0];
+            _btBauds_ptr = &btBauds_HM10_11[0];
+            break;
+        case HM12:
+        case HM13:
+            // HM-12/13
+            _isEdrSupported = true;
+            _validBaudBounds_ptr = &btBauds_validRange_HM12_13[0];
+            _btBauds_ptr = &btBauds_HM12_13[0];
+            break;
+        case HM14:
+        case HM15:
+        case HM16:
+        case HM17:
+        case HM18:
+        case HM19:
+            // HM-14 to 19
+            _isEdrSupported = false;
+            _validBaudBounds_ptr = &btBauds_validRange_HM16_17_18_19[0];
+            _btBauds_ptr = &btBauds_HM16_17_18_19[0];
+            break;
+    }
 }

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -2760,38 +2760,41 @@ void HM1X_BT::setI2cAddress(uint8_t address)
 
 HM1X_error_t HM1X_BT::forceBaud(unsigned long baud)
 {
+    HM1X_error_t err;
     switch (baud) {
     case 1200:
-        forceBaud(HM1X_BAUD_1200);
+        err = forceBaud(HM1X_BAUD_1200);
         break;
     case 2400:
-        forceBaud(HM1X_BAUD_2400);
+        err = forceBaud(HM1X_BAUD_2400);
         break;
     case 4800:
-        forceBaud(HM1X_BAUD_4800);
+        err = forceBaud(HM1X_BAUD_4800);
         break;
     case 9600:
-        forceBaud(HM1X_BAUD_9600);
+        err = forceBaud(HM1X_BAUD_9600);
         break;
     case 19200:
-        forceBaud(HM1X_BAUD_19200);
+        err = forceBaud(HM1X_BAUD_19200);
         break;
     case 38400:
-        forceBaud(HM1X_BAUD_38400);
+        err = forceBaud(HM1X_BAUD_38400);
         break;
     case 57600:
-        forceBaud(HM1X_BAUD_57600);
+        err = forceBaud(HM1X_BAUD_57600);
         break;
     case 115200:
-        forceBaud(HM1X_BAUD_115200);
+        err = forceBaud(HM1X_BAUD_115200);
         break;
     case 230400:
-        forceBaud(HM1X_BAUD_230400);
+        err = forceBaud(HM1X_BAUD_230400);
         break;
     default:
-        // Do nothing on unsupported baud
-        break;
+        // Return error on unsupported baud
+        err = HM1X_ERROR_ER;
     }
+
+    return err;
 }
 
 HM1X_error_t HM1X_BT::forceBaud(HM1X_baud_t baud)

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -2384,7 +2384,7 @@ HM1X_error_t HM1X_BT::setBaud(HM1X_baud_t atob)
     char * command;
     char * response;
     char * hsParam;
-    char * baudChar;
+    char * baudChar = (char*)"0";
     uint8_t baudCharNum;
 
     command = (char *) calloc(strlen(HM1X_COMMAND_BAUD) + 2, sizeof(char));
@@ -2397,7 +2397,8 @@ HM1X_error_t HM1X_BT::setBaud(HM1X_baud_t atob)
         return HM1X_UNEXPECTED_RESPONSE;
     
     }
-    baudChar = (char*)"0" + baudCharNum;
+
+    baudChar[0] = (char)'0' + baudCharNum;
 
     strcpy(command, HM1X_COMMAND_BAUD);
     strcat(command, baudChar);
@@ -2412,7 +2413,7 @@ HM1X_error_t HM1X_BT::setBaud(HM1X_baud_t atob)
     strcat(response, HM1X_RESPONSE_OK);
     strcat(response, HM1X_RESPONSE_SET);
     strcat(response, baudChar);
-
+    
     err = sendCommandWithResponseAndTimeout(command, response, HM1X_DEFAULT_TIMEOUT);
     
     free(command);

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -864,6 +864,21 @@ HM1X_error_t HM1X_BT::setBleName(const char * name)
     char * command;
     char * response;
     int nameLen;
+    char *command_no_ble;
+
+    command_no_ble = (char*) calloc(strlen(HM1X_COMMAND_BLE_NAME), sizeof(char));
+    if (command_no_ble == NULL)
+    {
+        return HM1X_OUT_OF_MEMORY;
+    }
+    // check if EDR is disabled
+    if ( !_isEdrSupported ){
+        // use the code for Edr (main)
+        strcpy(command_no_ble, HM1X_COMMAND_EDR_NAME);
+    }else{
+        // use HM1X_COMMAND_BLE_NAME as is
+        strcpy(command_no_ble, HM1X_COMMAND_BLE_NAME);
+    }
 
     nameLen = strlen(name);
 
@@ -873,12 +888,12 @@ HM1X_error_t HM1X_BT::setBleName(const char * name)
     }
 
     // Build command: e.g. AT+NAMBMY_BLE_DEVICE
-    command = (char *) calloc(strlen(HM1X_COMMAND_BLE_NAME) + nameLen + 2, sizeof(char));
+    command = (char *) calloc(strlen(command_no_ble) + nameLen + 2, sizeof(char));
     if (command == NULL)
     {
         return HM1X_OUT_OF_MEMORY;
     }
-    strcat(command, HM1X_COMMAND_BLE_NAME);
+    strcat(command, command_no_ble);
     strcat(command, name);
 
     // Build expected response: e.g. OK+Set:MY_BLE_DEVICE
@@ -896,6 +911,7 @@ HM1X_error_t HM1X_BT::setBleName(const char * name)
     
     free(command);
     free(response);
+    free(command_no_ble);
 
     return err;
 }

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -126,6 +126,7 @@ static const uint8_t btBauds_validRange_HM10_11[2] =        {0, 8};
 static const uint8_t btBauds_validRange_HM16_17_18_19[2] =  {0, 8};
 static const uint8_t btBauds_validRange_HM12_13[2] =        {1, 7};
 
+// Class Constructor
 HM1X_BT::HM1X_BT(HM1X_model_t btModel)
 {
     _btModel = btModel;
@@ -138,6 +139,10 @@ HM1X_BT::HM1X_BT(HM1X_model_t btModel)
 
     _polling = false;
 
+    // set model-specific variables
+    // _isEdrSupported, _btBauds_ptr, and _validBaudBounds_ptr
+    setModelSpecificVariables();
+
 #ifdef HM1X_SOFTWARE_SERIAL_ENABLED
     _softSerial = NULL;
 #endif
@@ -148,6 +153,12 @@ HM1X_BT::HM1X_BT(HM1X_model_t btModel)
     _wirePort = NULL;
     _wireAddress = 0;
 #endif
+}
+
+// set model-specific variables
+    // _isEdrSupported, _btBauds_ptr, and _validBaudBounds_ptr
+void HM1X_BT::setModelSpecificVariables(void){
+    
 }
 
 #ifdef HM1X_SOFTWARE_SERIAL_ENABLED

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -804,14 +804,29 @@ HM1X_error_t HM1X_BT::getBleName(char * name)
     char * command;
     char * response;
     int retNameLen;
+    char *command_no_ble;
+
+    command_no_ble = (char*) calloc(strlen(HM1X_COMMAND_BLE_NAME), sizeof(char));
+    if (command_no_ble == NULL)
+    {
+        return HM1X_OUT_OF_MEMORY;
+    }
+    // check if EDR is disabled
+    if ( !_isEdrSupported ){
+        // use the code for Edr (main)
+        strcpy(command_no_ble, HM1X_COMMAND_EDR_NAME);
+    }else{
+        // use HM1X_COMMAND_BLE_NAME as is
+        strcpy(command_no_ble, HM1X_COMMAND_BLE_NAME);
+    }
 
     // Create command string: AT+NAMB?
-    command = (char *) calloc(strlen(HM1X_COMMAND_BLE_NAME) + strlen(HM1X_QUERY_STRING) + 2, sizeof(char));
+    command = (char *) calloc(strlen(command_no_ble) + strlen(HM1X_QUERY_STRING) + 2, sizeof(char));
     if (command == NULL)
     {
         return HM1X_OUT_OF_MEMORY;
     }
-    strcat(command, HM1X_COMMAND_BLE_NAME);
+    strcat(command, command_no_ble);
     strcat(command, HM1X_QUERY_STRING);
 
     // Allocate enough memory for a response (up to 28 bytes + "OK+Get:")
@@ -830,6 +845,7 @@ HM1X_error_t HM1X_BT::getBleName(char * name)
 
     free(response);
     free(command);
+    free(command_no_ble);
     
     return HM1X_SUCCESS;
 }

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -115,7 +115,7 @@ typedef enum {
 } qwiic_bt_commands_t;
 #endif
 
-static const long btBauds[HM1X_BT::NUM_HM1X_BAUDS] = {0, 4800, 9600, 19200, 38400, 57600, 115200, 320400};
+static const long btBauds[HM1X_BT::NUM_HM1X_BAUDS] = {0, 4800, 9600, 19200, 38400, 57600, 115200, 230400};
 
 HM1X_BT::HM1X_BT(HM1X_model_t btModel)
 {

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -638,10 +638,13 @@ HM1X_error_t HM1X_BT::notify(boolean enabled, boolean withAddress)
     return err;
 }
 
+// gets EDR name as return value
+// does not support HM-15/16/17/18/19
 String HM1X_BT::getEdrName(void)
 {
     char * name;
     String retName = "";
+
     name = (char *)malloc(32* sizeof(char));
     if (name != NULL)
     {
@@ -653,13 +656,22 @@ String HM1X_BT::getEdrName(void)
     return retName;
 }
 
-// AT+NAME, AT+NAMB -- Set EDR/BLE name
+// Set EDR name and copy it to the character array name
+// does not support HM-15/16/17/18/19
 HM1X_error_t HM1X_BT::getEdrName(char * name)
 {
     HM1X_error_t err;
     char * command;
     char * response;
     int retNameLen;
+
+    // Check if EDR is supported
+    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    {
+        // HM-15 to HM-19 does not support EDR
+        // return error
+        return HM1X_ERROR_ER;
+    }
 
     // Create command string: AT+NAME?
     command = (char *) calloc(strlen(HM1X_COMMAND_EDR_NAME) + strlen(HM1X_QUERY_STRING) + 2, sizeof(char));
@@ -690,20 +702,40 @@ HM1X_error_t HM1X_BT::getEdrName(char * name)
     return HM1X_SUCCESS;
 }
 
+// Set the EDR device name with the input string parameter
+// does not support HM-15/16/17/18/19
 HM1X_error_t HM1X_BT::setEdrName(String name)
 {
     char * edrChar;
+
+    // Check if EDR is supported
+    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    {
+        // HM-15 to HM-19 does not support EDR
+        // return error
+        return HM1X_ERROR_ER;
+    }
+
     edrChar = (char *) calloc(name.length() + 1, sizeof(char));
     name.toCharArray(edrChar, name.length() + 1);
     return setEdrName(edrChar);
 }
 
+// Set EDR name and copy it to the character array name
 HM1X_error_t HM1X_BT::setEdrName(const char * name)
 {
     HM1X_error_t err;
     char * command;
     char * response;
     int nameLen;
+
+    // Check if EDR is supported
+    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    {
+        // HM-15 to HM-19 does not support EDR
+        // return error
+        return HM1X_ERROR_ER;
+    }
 
     nameLen = strlen(name);
 

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -2421,6 +2421,10 @@ HM1X_error_t HM1X_BT::setBaud(HM1X_baud_t atob)
     return err;
 }
 
+/////////////
+// Private //
+/////////////
+
 // returns the integer that corresponds to the correct baud rate depending on the model
 HM1X_error_t HM1X_BT::findBaudFromArray(HM1X_baud_t atob, uint8_t &num){
     
@@ -2444,10 +2448,6 @@ HM1X_error_t HM1X_BT::findBaudFromArray(HM1X_baud_t atob, uint8_t &num){
     return HM1X_UNEXPECTED_RESPONSE;
     
 }
-
-/////////////
-// Private //
-/////////////
 
 HM1X_error_t HM1X_BT::init(void)
 {

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -873,6 +873,8 @@ HM1X_error_t HM1X_BT::setBleName(const char * name)
     return err;
 }
 
+// checks EDR address
+// does not support HM-15/16/17/18/19
 String HM1X_BT::edrAddress(void)
 {
     char * address;
@@ -885,10 +887,18 @@ String HM1X_BT::edrAddress(void)
 }
 
 // AT+ADDE -- EDR address
+// does not support HM-15/16/17/18/19
 HM1X_error_t HM1X_BT::edrAddress(char * retAddress)
 {
     char * command;
     char * response;
+
+    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    {
+        // HM-15 to HM-19 does not support EDR
+        // return error
+        return HM1X_ERROR_ER;
+    }
 
     command = (char *) calloc(strlen(HM1X_COMMAND_EDR_ADR) + strlen(HM1X_QUERY_STRING) + 1, sizeof(char));
     if (command == NULL) return HM1X_OUT_OF_MEMORY;
@@ -944,10 +954,19 @@ HM1X_error_t HM1X_BT::bleAddress(char * retAddress)
 }
 
 // AT+RADE, AT+RADB -- Last connected EDR/BLE address
+// does not support HM-15/16/17/18/19
 HM1X_error_t HM1X_BT::lastEdrAddress(char * address)
 {
     char * command;
     char * response;
+
+    // Check if EDR is supported
+    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    {
+        // HM-15 to HM-19 does not support EDR
+        // return error
+        return HM1X_ERROR_ER;
+    }
 
     command = (char *) calloc(strlen(HM1X_COMMAND_LAST_EDR) + strlen(HM1X_QUERY_STRING) + 1, sizeof(char));
     if (command == NULL) return HM1X_OUT_OF_MEMORY;
@@ -991,11 +1010,20 @@ HM1X_error_t HM1X_BT::lastBleAddress(char * address)
 }
 
 // AT+BONDE, AT+BONDB --- Clear EDR/BLE bond info
+// does not support HM-15/16/17/18/19
 HM1X_error_t HM1X_BT::clearEdrBond(void)
 {
     HM1X_error_t err;
     char * command;
     char * response;
+
+    // Check if EDR is supported
+    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    {
+        // HM-15 to HM-19 does not support EDR
+        // return error
+        return HM1X_ERROR_ER;
+    }
 
     // Build command: e.g. AT+BONDE
     command = (char *) calloc(strlen(HM1X_COMMAND_CLEAR_BOND_EDR) + 1, sizeof(char));
@@ -1060,11 +1088,20 @@ HM1X_error_t HM1X_BT::clearBleBond(void)
 }
 
 // AT+CLEAE, AT+CLEAB -- Clear last connected EDR/BLE address
+// does not support HM-15/16/17/18/19
 HM1X_error_t HM1X_BT::clearEdrConnected(void)
 {
     HM1X_error_t err;
     char * command;
     char * response;
+
+    // Check if EDR is supported
+    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    {
+        // HM-15 to HM-19 does not support EDR
+        // return error
+        return HM1X_ERROR_ER;
+    }
 
     // Build command: e.g. AT+CLEAE
     command = (char *) calloc(strlen(HM1X_COMMAND_CLEAR_ADR_EDR) + 1, sizeof(char));
@@ -1129,10 +1166,19 @@ HM1X_error_t HM1X_BT::clearBleConnected(void)
 }
 
 // AT+ROLE, AT+ROLB -- EDR/BLE mode
+// does not support HM-15/16/17/18/19
 HM1X_error_t HM1X_BT::getEdrMode(HM1X_edr_mode_t * mode)
 {
     char * command;
     char * response;
+
+    // Check if EDR is supported
+    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    {
+        // HM-15 to HM-19 does not support EDR
+        // return error
+        return HM1X_ERROR_ER;
+    }
 
     // Set command string: "AT+ROLE?""
     command = (char *) calloc(strlen(HM1X_COMMAND_EDR_MODE) + strlen(HM1X_QUERY_STRING) + 1, sizeof(char));
@@ -1167,12 +1213,22 @@ HM1X_error_t HM1X_BT::getEdrMode(HM1X_edr_mode_t * mode)
     return HM1X_SUCCESS;
 }
 
+// sets the EDR mode
+// does not support HM-15/16/17/18/19
 HM1X_error_t HM1X_BT::setEdrMode(HM1X_edr_mode_t mode)
 {
     HM1X_error_t err;
     char * command;
     char * response;
     char modeParam;
+
+    // Check if EDR is supported
+    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    {
+        // HM-15 to HM-19 does not support EDR
+        // return error
+        return HM1X_ERROR_ER;
+    }
     
     if (mode == EDR_MODE_INVALID)
     {
@@ -1305,13 +1361,20 @@ HM1X_error_t HM1X_BT::enableHighSpeedSPP(boolean enabled)
     return err;
 }
 
-
+// This is only supported in HM12/13/14
 HM1X_error_t HM1X_BT::enableDualMode(boolean enabled)
 {
     HM1X_error_t err;
     char * command;
     char * response;
     char hsParam;
+
+    // Check if device is supported
+    if( (_btModel != HM12) || (_btModel != HM13) || (_btModel != HM14))
+    {
+        // devices other than HM12/13/14 are not supported
+        return HM1X_ERROR_ER;
+    }
 
     // Build command: e.g. AT+DUAL0
     command = (char *) calloc(strlen(HM1X_COMMAND_DUAL_WORK_MODE) + 2, sizeof(char));
@@ -1432,10 +1495,19 @@ HM1X_error_t HM1X_BT::enableAuthenticationMode(boolean enable)
 }
 
 // AT+PINE, AT+PINB -- EDR/BLE PIN Code
+// does not support HM-15/16/17/18/19
 HM1X_error_t HM1X_BT::getEdrPin(char * code)
 {
     char * command;
     char * response;
+
+    // Check if EDR is supported
+    if ( (_btModel >= HM15) && (_btModel <= HM19))
+    {
+        // HM-15 to HM-19 does not support EDR
+        // return error
+        return HM1X_ERROR_ER;
+    }
 
     // Set command string: "AT+PINE?""
     command = (char *) calloc(strlen(HM1X_COMMAND_EDR_PIN_CODE) + strlen(HM1X_QUERY_STRING) + 1, sizeof(char));

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -2397,7 +2397,7 @@ HM1X_error_t HM1X_BT::setBaud(HM1X_baud_t atob)
         return HM1X_UNEXPECTED_RESPONSE;
     
     }
-    baudChar = "0" + baudCharNum;
+    baudChar = static_cast<char*>("0") + baudCharNum;
 
     strcpy(command, HM1X_COMMAND_BAUD);
     strcat(command, baudChar);
@@ -2761,6 +2761,12 @@ void HM1X_BT::setI2cAddress(uint8_t address)
 HM1X_error_t HM1X_BT::forceBaud(unsigned long baud)
 {
     switch (baud) {
+    case 1200:
+        forceBaud(HM1X_BAUD_1200);
+        break;
+    case 2400:
+        forceBaud(HM1X_BAUD_2400);
+        break;
     case 4800:
         forceBaud(HM1X_BAUD_4800);
         break;

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -2385,43 +2385,20 @@ HM1X_error_t HM1X_BT::setBaud(HM1X_baud_t atob)
     char * response;
     char * hsParam;
     char * baudChar;
-
-    if ((atob >= NUM_HM1X_BAUDS))
-    {
-        return HM1X_UNEXPECTED_RESPONSE;
-    }
+    uint8_t baudCharNum;
 
     command = (char *) calloc(strlen(HM1X_COMMAND_BAUD) + 2, sizeof(char));
     if (command == NULL) return HM1X_OUT_OF_MEMORY;
 
     // Build command: e.g. AT+BAUD2
-    switch (atob)
-    {
-        case HM1X_BAUD_4800:
-            baudChar = "1";
-            break;
-        case HM1X_BAUD_9600:
-            baudChar = "2";
-            break;
-        case HM1X_BAUD_19200:
-            baudChar = "3";
-            break;
-        case HM1X_BAUD_38400:
-            baudChar = "4";
-            break;
-        case HM1X_BAUD_57600:
-            baudChar = "5";
-            break;
-        case HM1X_BAUD_115200:
-            baudChar = "6";
-            break;
-        case HM1X_BAUD_230400:
-            baudChar = "7";
-            break;
-        default:
-            baudChar = "2";
-            break;
+    // Handle cases according to model
+    if (findBaudFromArray(atob, baudCharNum) != HM1X_SUCCESS){
+
+        return HM1X_UNEXPECTED_RESPONSE;
+    
     }
+    baudChar = "0" + baudCharNum;
+
     strcpy(command, HM1X_COMMAND_BAUD);
     strcat(command, baudChar);
 

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -2397,7 +2397,7 @@ HM1X_error_t HM1X_BT::setBaud(HM1X_baud_t atob)
         return HM1X_UNEXPECTED_RESPONSE;
     
     }
-    baudChar = static_cast<char*>("0") + baudCharNum;
+    baudChar = (char*)"0" + baudCharNum;
 
     strcpy(command, HM1X_COMMAND_BAUD);
     strcat(command, baudChar);
@@ -2797,12 +2797,15 @@ HM1X_error_t HM1X_BT::forceBaud(unsigned long baud)
     return err;
 }
 
+// sweeps for all possible baud rates then force-set to the indicated baud rate
 HM1X_error_t HM1X_BT::forceBaud(HM1X_baud_t baud)
 {    
     HM1X_error_t err;
+    uint8_t idx;
 
-    for (uint8_t i = HM1X_BAUD_4800; i < NUM_HM1X_BAUDS; i++) 
+    for (uint8_t i = _validBaudBounds_ptr[0]; i < _validBaudBounds_ptr[1]; i++) 
     {
+        idx = _btBauds_ptr[i];
         if (0)
         {
             
@@ -2810,7 +2813,7 @@ HM1X_error_t HM1X_BT::forceBaud(HM1X_baud_t baud)
 #ifdef HM1X_SOFTWARE_SERIAL_ENABLED
         else if (_softSerial != NULL)
         {
-            _softSerial->begin(btBauds[i]);
+            _softSerial->begin(btBauds[idx]);
         }
 #endif
 #ifdef HM1X_I2C_ENABLED
@@ -2822,7 +2825,7 @@ HM1X_error_t HM1X_BT::forceBaud(HM1X_baud_t baud)
 #ifdef HM1X_HARDWARE_SERIAL_ENABLED
         else if (_serialPort != NULL)
         {
-            _serialPort->begin(btBauds[i]);
+            _serialPort->begin(btBauds[idx]);
         }
 #endif
         err = setBaud(baud);

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -115,7 +115,16 @@ typedef enum {
 } qwiic_bt_commands_t;
 #endif
 
-static const long btBauds[HM1X_BT::NUM_HM1X_BAUDS] = {0, 4800, 9600, 19200, 38400, 57600, 115200, 230400};
+static const long btBauds[HM1X_BT::NUM_HM1X_BAUDS] = {1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400};
+
+// These are arrays that maps the required baudChar for each desired baud rate declared in the enum HM1X_baud_t
+static const uint8_t btBauds_HM10_11[HM1X_BT::NUM_HM1X_BAUDS] =        {3, 4, 5, 6, 7, 2, 1, 0, 8};
+static const uint8_t btBauds_HM16_17_18_19[HM1X_BT::NUM_HM1X_BAUDS] =  {0, 1, 2, 3, 4, 5, 6, 7, 8};
+static const uint8_t btBauds_HM12_13[HM1X_BT::NUM_HM1X_BAUDS] =        {0, 2, 3, 4, 5, 6, 7, 8, 0};
+
+static const uint8_t btBauds_validRange_HM10_11[2] =        {0, 8};
+static const uint8_t btBauds_validRange_HM16_17_18_19[2] =  {0, 8};
+static const uint8_t btBauds_validRange_HM12_13[2] =        {1, 7};
 
 HM1X_BT::HM1X_BT(HM1X_model_t btModel)
 {

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -156,9 +156,37 @@ HM1X_BT::HM1X_BT(HM1X_model_t btModel)
 }
 
 // set model-specific variables
-    // _isEdrSupported, _btBauds_ptr, and _validBaudBounds_ptr
+// _isEdrSupported, _btBauds_ptr, and _validBaudBounds_ptr
 void HM1X_BT::setModelSpecificVariables(void){
-    
+
+    switch(_btModel)
+    {
+        case HM10:
+        case HM11:
+            // HM-10/11: only allow P0~8
+            _isEdrSupported = false;
+            _validBaudBounds_ptr = &btBauds_validRange_HM10_11[0];
+            _btBauds_ptr = &btBauds_HM10_11[0];
+            break;
+        case HM12:
+        case HM13:
+            // HM-12/13
+            _isEdrSupported = true;
+            _validBaudBounds_ptr = &btBauds_validRange_HM12_13[0];
+            _btBauds_ptr = &btBauds_HM12_13[0];
+            break;
+        case HM14:
+        case HM15:
+        case HM16:
+        case HM17:
+        case HM18:
+        case HM19:
+            // HM-14 to 19
+            _isEdrSupported = false;
+            _validBaudBounds_ptr = &btBauds_validRange_HM16_17_18_19[0];
+            _btBauds_ptr = &btBauds_HM16_17_18_19[0];
+            break;
+    }
 }
 
 #ifdef HM1X_SOFTWARE_SERIAL_ENABLED
@@ -2401,7 +2429,7 @@ HM1X_error_t HM1X_BT::setBaud(HM1X_baud_t atob)
     char * hsParam;
     char * baudChar;
 
-    if ((atob == HM1X_BAUD_INVALID) || (atob >= NUM_HM1X_BAUDS))
+    if ((atob >= NUM_HM1X_BAUDS))
     {
         return HM1X_UNEXPECTED_RESPONSE;
     }

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -48,8 +48,10 @@ const char HM1X_COMMAND_EDR_NAME[] = "NAME";
 const char HM1X_COMMAND_BLE_NAME[] = "NAMB";
 const char HM1X_COMMAND_EDR_ADR[] = "ADDE";
 const char HM1X_COMMAND_BLE_ADR[] = "ADDB";
+const char HM1X_COMMAND_BLE_ADR_SINGLE[] = "ADDR";
 const char HM1X_COMMAND_LAST_EDR[] = "RADE";
 const char HM1X_COMMAND_LAST_BLE[] = "RADB";
+const char HM1X_COMMAND_LAST_SINGLE[] = "RADD";
 const char HM1X_COMMAND_CLEAR_BOND_EDR[] = "BONDE";
 const char HM1X_COMMAND_CLEAR_BOND_BLE[] = "BONDB";
 const char HM1X_COMMAND_CLEAR_ADR_EDR[] = "CLEAE";
@@ -876,7 +878,7 @@ HM1X_error_t HM1X_BT::setBleName(const char * name)
         // use the code for Edr (main)
         strcpy(command_no_ble, HM1X_COMMAND_EDR_NAME);
     }else{
-        // use HM1X_COMMAND_BLE_NAME as is
+        // use as is
         strcpy(command_no_ble, HM1X_COMMAND_BLE_NAME);
     }
 
@@ -973,14 +975,30 @@ String HM1X_BT::bleAddress(void)
 }
 
 // AT+ADDB -- BLE address
+// AT+ADDR for non-dual devices
 HM1X_error_t HM1X_BT::bleAddress(char * retAddress)
 {
     char * command;
     char * response;
+    char *command_no_ble;
 
-    command = (char *) calloc(strlen(HM1X_COMMAND_BLE_ADR) + strlen(HM1X_QUERY_STRING) + 1, sizeof(char));
+    command_no_ble = (char*) calloc(strlen(HM1X_COMMAND_BLE_ADR_SINGLE), sizeof(char));
+    if (command_no_ble == NULL)
+    {
+        return HM1X_OUT_OF_MEMORY;
+    }
+    // check if EDR is disabled
+    if ( !_isEdrSupported ){
+        // use the code for Edr (main)
+        strcpy(command_no_ble, HM1X_COMMAND_BLE_ADR_SINGLE);
+    }else{
+        // use as is
+        strcpy(command_no_ble, HM1X_COMMAND_BLE_NAME);
+    }
+
+    command = (char *) calloc(strlen(command_no_ble) + strlen(HM1X_QUERY_STRING) + 1, sizeof(char));
     if (command == NULL) return HM1X_OUT_OF_MEMORY;
-    strcpy(command, HM1X_COMMAND_BLE_ADR);
+    strcpy(command, command_no_ble);
     strcat(command, HM1X_QUERY_STRING);
 
     response = (char *) calloc(20 + 1, sizeof(char));
@@ -992,6 +1010,7 @@ HM1X_error_t HM1X_BT::bleAddress(char * retAddress)
     
     free(response);
     free(command);
+    free(command_no_ble);
 
     return HM1X_SUCCESS;
 }
@@ -1032,10 +1051,25 @@ HM1X_error_t HM1X_BT::lastBleAddress(char * address)
 {
     char * command;
     char * response;
+    char *command_no_ble;
 
-    command = (char *) calloc(strlen(HM1X_COMMAND_LAST_BLE) + strlen(HM1X_QUERY_STRING) + 1, sizeof(char));
+    command_no_ble = (char*) calloc(strlen(HM1X_COMMAND_LAST_BLE), sizeof(char));
+    if (command_no_ble == NULL)
+    {
+        return HM1X_OUT_OF_MEMORY;
+    }
+    // check if EDR is disabled
+    if ( !_isEdrSupported ){
+        // use the code for Edr (main)
+        strcpy(command_no_ble, HM1X_COMMAND_LAST_SINGLE);
+    }else{
+        // use as is
+        strcpy(command_no_ble, HM1X_COMMAND_LAST_BLE);
+    }
+
+    command = (char *) calloc(strlen(command_no_ble) + strlen(HM1X_QUERY_STRING) + 1, sizeof(char));
     if (command == NULL) return HM1X_OUT_OF_MEMORY;
-    strcpy(command, HM1X_COMMAND_LAST_BLE);
+    strcpy(command, command_no_ble);
     strcat(command, HM1X_QUERY_STRING);
 
     response = (char *) calloc(20 + 1, sizeof(char));
@@ -1047,6 +1081,7 @@ HM1X_error_t HM1X_BT::lastBleAddress(char * address)
 
     free(response);
     free(command);
+    free(command_no_ble);
     
     return HM1X_SUCCESS;
 }

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.cpp
@@ -1492,10 +1492,10 @@ HM1X_error_t HM1X_BT::enableDualMode(boolean enabled)
     char * response;
     char hsParam;
 
-    // Check if device is supported
-    if( (_btModel != HM12) || (_btModel != HM13) || (_btModel != HM14))
+    // Check if EDR is supported
+    if ( !_isEdrSupported )
     {
-        // devices other than HM12/13/14 are not supported
+        // return error
         return HM1X_ERROR_ER;
     }
 

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
@@ -319,10 +319,10 @@ private:
 
     // pointer to the proper baud mapping array per model
     // should be set during class construction
-    uint8_t * _btBauds_ptr;
+    uint8_t const * _btBauds_ptr;
 
     // pointer to valid baud indices
-    uint8_t * _validBaudBounds_ptr;
+    uint8_t const * _validBaudBounds_ptr;
 
     // boolean to determine whether EDR is supported
     // should be set during class construction

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
@@ -292,7 +292,6 @@ public:
     } HM1X_baud_t;
     HM1X_error_t setBaud(HM1X_baud_t atob);
     HM1X_error_t setBaud(uint32_t baud);
-    HM1X_error_t findBaudFromArray(HM1X_baud_t atob, uint8_t &num);
 
 private:
     
@@ -330,6 +329,8 @@ private:
     boolean _isEdrSupported;
 
     void setModelSpecificVariables();
+
+    HM1X_error_t findBaudFromArray(HM1X_baud_t atob, uint8_t &num);
 
     HM1X_error_t init(void);
 

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
@@ -292,6 +292,7 @@ public:
     } HM1X_baud_t;
     HM1X_error_t setBaud(HM1X_baud_t atob);
     HM1X_error_t setBaud(uint32_t baud);
+    HM1X_error_t findBaudFromArray(HM1X_baud_t atob, uint8_t &num);
 
 private:
     

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
@@ -71,6 +71,8 @@ typedef enum {
     HM1X_SUCCESS             = 0
 } HM1X_error_t;
 
+
+
 class HM1X_BT : public Print {
 public:
     

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
@@ -318,7 +318,17 @@ private:
     boolean _polling;
 
     // pointer to the proper baud mapping array per model
+    // should be set during class construction
     uint8_t * _btBauds_ptr;
+
+    // pointer to valid baud indices
+    uint8_t * _validBaudBounds_ptr;
+
+    // boolean to determine whether EDR is supported
+    // should be set during class construction
+    boolean _isEdrSupported;
+
+    void setModelSpecificVariables();
 
     HM1X_error_t init(void);
 

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
@@ -279,7 +279,8 @@ public:
 
     // AT+BAUD -- Baud rate
     typedef enum {
-        HM1X_BAUD_INVALID,
+        HM1X_BAUD_1200,
+        HM1X_BAUD_2400,
         HM1X_BAUD_4800,
         HM1X_BAUD_9600,
         HM1X_BAUD_19200,

--- a/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
+++ b/src/SparkFun_HM1X_Bluetooth_Arduino_Library.h
@@ -316,6 +316,9 @@ private:
 
     boolean _polling;
 
+    // pointer to the proper baud mapping array per model
+    uint8_t * _btBauds_ptr;
+
     HM1X_error_t init(void);
 
     // Send command with an expected response string/length -- e.g. "OK":


### PR DESCRIPTION
Hi Sparkfun!

I modified the library to support other HM-1X devices especially for devices that does not support dual-mode (EDR + BLE).

I don't have an HM-12/13 right now so I am not sure if this is back-compatible but it should be.

Changelog:
・ Added checks on EDR-specific functions for models that does not support EDR 
・ Added support for non-dual mode devices (tested only on HM-19), with corresponding sample sketch
	┗ getBleName(), setBleName()
	┗ bleAddress()
	┗ lastBleAddress()
	┗ clearBleConnected() - 
	┗ getBleMode(), setBleMode()
	┗ getBlePin(), setBlePin()
・ Added proper setBaud() and forceBaud() support for HM-1X other than 12/13.
	Baud rates (based on the original HM-1X manufacturer website http://www.jnhuamao.cn/
	
Please let me know if there are bugs when using the older models (HM12/13) so I can fix it.
